### PR TITLE
Fix the scroll bar from disappearing when hiding services

### DIFF
--- a/src/views/service-tree.coffee
+++ b/src/views/service-tree.coffee
@@ -79,6 +79,7 @@ define (require) ->
             serviceNodeId = $targetElement.closest('li').data('service-node-id')
             if @selected serviceNodeId
                 app.request 'removeServiceNode', serviceNodeId
+                app.navigation.currentView.setMaxHeight()
             else
                 serviceNode = new models.ServiceNode id: serviceNodeId
                 serviceNode.fetch


### PR DESCRIPTION
Fix the scroll bar from disappearing when 'hide' button is
clicked to hide the services/units.

Refs 9786