### PR TITLE
Fix the colors on the markers by changing the lookup service_nodes

### DIFF
--- a/src/color.coffee
+++ b/src/color.coffee
@@ -25,16 +25,16 @@ define (require) ->
                         type: 'helfi_rest_api_v4'
                 roots = [@defaultRootColor]
 
-            findRootInServiceItems = (rootIds, serviceCollection) ->
+            findRootInServiceItems = (rootIds, serviceCollection, unit) ->
                 _(rootIds).find (rootId) ->
                     serviceCollection.find (serviceItem) ->
-                        serviceItem.getRoot() is rootId
+                        serviceItem.getRoot() is rootId and serviceItem._previousAttributes.units.models.includes unit
 
             if @selectedServices?
                 rootServiceNode = findRootInServiceItems roots, @selectedServices
 
             if not rootServiceNode and @selectedServiceNodes?
-                rootServiceNode = findRootInServiceItems roots, @selectedServiceNodes
+                rootServiceNode = findRootInServiceItems roots, @selectedServiceNodes, unit
 
             if not rootServiceNode
                 rootServiceNode = roots[0]


### PR DESCRIPTION
The colors for markers are calculated by looking up the service_nodes.
When units are fetched for a service_node(say 1_31) for first time, the colour is 
determined by looking up against the service_node(1_31).

Next, when another service_node(say 1_34) is clicked, collections is updated
to contain all the units belonging to 1_31 and 1_34. For each unit, the colour
is determined by looking up against service_node 1_31 first and then 1_34.

However what should happen is units fetched first time should be looked
up against 1_31 and units fetched second time should be looked up against
1_34.

Therefore we need to track the units fetched for each service_node and
determine the colour by looking up against the service_node it belongs
to.

Refs Bug 9782 + Bug 9833