### PR TITLE
Display units belonging to root service nodes

### DIFF
--- a/src/color.coffee
+++ b/src/color.coffee
@@ -28,13 +28,19 @@ define (require) ->
             findRootInServiceItems = (rootIds, serviceCollection, unit) ->
                 _(rootIds).find (rootId) ->
                     serviceCollection.find (serviceItem) ->
-                        serviceItem.getRoot() is rootId and serviceItem._previousAttributes.units.models.includes unit
+                        if serviceItem._previousAttributes.units
+                            return serviceItem.getRoot() is rootId and serviceItem._previousAttributes.units and serviceItem._previousAttributes.units.models.includes unit
+                        else
+                            return serviceItem.getRoot() is rootId
 
             if @selectedServices?
                 rootServiceNode = findRootInServiceItems roots, @selectedServices
 
             if not rootServiceNode and @selectedServiceNodes?
                 rootServiceNode = findRootInServiceItems roots, @selectedServiceNodes, unit
+
+            if not rootServiceNode and unit.extra_color?
+                rootServiceNode = unit.extra_color
 
             if not rootServiceNode
                 rootServiceNode = roots[0]

--- a/views/templates/service-tree.jade
+++ b/views/templates/service-tree.jade
@@ -25,10 +25,13 @@ ul.main-list.navi.service-tree.limit-max-height
         span.icon-icon-forward-bold(aria-hidden='true')
       span.service-node-name.vertically-aligned= item.name
       a(href="#", class="show-service-nodes-button" role="button")
-          span(class="#{item.show_button_classes}")
-            if item.selected
-              = t('sidebar.hide')
-            else
-              = t('sidebar.show')
-          .service-point-count
-            != t('general.units', {count: item.count})
+          if item.count != undefined
+            span(class="#{item.show_button_classes}")
+              if item.selected
+                = t('sidebar.hide')
+              else
+                = t('sidebar.show')
+            .service-point-count
+              != t('general.units', {count: item.count})
+          else
+            span(class="#{item.show_button_classes}" style="visibility: hidden;")


### PR DESCRIPTION
Display units beloning to root service nodes along side the child
service nodes. Since these units don't belong to sub-category,
these should be displayed when the parent node is clicked.

Refs Somewhat related to 9782