### PR TITLE
Don't display comma in front of the phone number if the name is missing

### DIFF
--- a/views/templates/details.jade
+++ b/views/templates/details.jade
@@ -10,7 +10,8 @@ mixin renderConnection(conn)
         = " "
         = conn.contact_person
       if conn.phone && (tAttr(conn.name).indexOf(conn.phone) === -1)
-        = ", "
+        if (tAttr(conn.name)).length > 0
+          = ", "
         span(itemprop="telephone")
           a(href="tel:#{phoneI18n(conn.phone)}")= conn.phone
       if conn.email


### PR DESCRIPTION
In some cases, titles are not translated and are therefore empty, but we still want to display the phone numbers. Remove the comma in these cases.

