### PR TITLE
Display the proper timestamp bus for arrivals

### DIFF
--- a/src/util/graphql.coffee
+++ b/src/util/graphql.coffee
@@ -41,7 +41,6 @@ define ->
                 mode
                 trip { tripHeadsign }
                 route { longName, shortName }
-                intermediateStops { name }
                 intermediatePlaces{
                     arrivalTime
                     name

--- a/src/util/graphql.coffee
+++ b/src/util/graphql.coffee
@@ -42,6 +42,10 @@ define ->
                 trip { tripHeadsign }
                 route { longName, shortName }
                 intermediateStops { name }
+                intermediatePlaces{
+                    arrivalTime
+                    name
+                }
                 startTime
                 endTime
                 from {

--- a/src/views/route.coffee
+++ b/src/views/route.coffee
@@ -350,17 +350,17 @@ define (require) ->
             #         if 'alerts' of step and step.alerts.length
             #             warning = step.alerts[0].alertHeaderText.someTranslation
             #         steps.push(text: text, warning: warning)
-            if leg.mode in MODES_WITH_STOPS and leg.intermediateStops
+            if leg.mode in MODES_WITH_STOPS and leg.intermediatePlaces
                 if 'alerts' of leg and leg.alerts.length
                     for alert in leg.alerts
                         steps.push(
                             text: ""
                             warning: alert.alertHeaderText.someTranslation
                         )
-                for stop in leg.intermediateStops
+                for stop in leg.intermediatePlaces
                     steps.push(
                         text: p13n.getTranslatedAttr(stop.translatedName) || stop.name
-                        time: moment(stop.arrival).format('LT')
+                        time: moment(stop.arrivalTime).format('HH:mm')
                     )
             steps
 


### PR DESCRIPTION
* Display the proper time (HH:mm) about the bus arrivals in the bus stops.
* Remove the intermediateStops field from the GrqphQL plan query

Refs 9992